### PR TITLE
Update for new Reveal.js versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This plugin let you add a countdown timer to your reveal.js presentations
 Using the plugin is easy. First, register it in your Reveal.js initialize block.
 
 ```javascript
-
+    // Old reveal versions
     Reveal.initialize({
         dependencies: [
             ....
@@ -17,6 +17,21 @@ Using the plugin is easy. First, register it in your Reveal.js initialize block.
         countdown: { defaultTime: 600, autostart: "no" }
       });
 
+
+// New reveal versions 
+  Reveal.configure({
+    ...
+    countdown: {
+      defaultTime: 900,
+      autostart: "no",
+      tDelta: 60,
+      playTickSoundLast: 10,
+      tickSound: "http://soundbible.com/grab.php?id=2044&type=mp3",
+      timeIsUpSound: "http://soundbible.com/grab.php?id=1746&type=mp3"
+    }
+  })
+  
+  Reveal.registerPlugin(RevealCountDown)
 ```
 
 Then simply add an element into your presentation:
@@ -55,7 +70,9 @@ The plugin can be configured with default values and settings in the initialize 
       tDelta: 60,
       playTickSoundLast: 10,
       tickSound: "http://soundbible.com/grab.php?id=2044&type=mp3",
-      timeIsUpSound: "http://soundbible.com/grab.php?id=1746&type=mp3"
+      timeIsUpSound: "http://soundbible.com/grab.php?id=1746&type=mp3",
+      plusKey: 171, //SPANISH keyboard
+      minusKey: 173 //SPANISH keyboard
     }
 ```
 
@@ -68,6 +85,42 @@ defaults are:
   tDelta: 30,
   playTickSoundLast: 10,
   tickSound: "",
-  timeIsUpSound: ""
+  timeIsUpSound: "",
+  plusKey: 187,
+  minusKey: 189
 }
+```
+
+
+## Integration with Custom Controls plugin
+
+You can integrate it with the custom control plugin
+
+```javascript
+  Reveal.configure({
+    customcontrols: {
+      controls: [
+        {
+          icon: '<i class="fas fa-hourglass-start"></i>',
+          title: 'Pause/Unpause timer (T)',
+          action: 'RevealCountDown.togglePauseTimer()'
+        }
+      ]
+
+    countdown: {
+      defaultTime: 900,
+      autostart: "no",
+      tDelta: 60,
+      playTickSoundLast: 10,
+      tickSound: "http://soundbible.com/grab.php?id=2044&type=mp3",
+      timeIsUpSound: "http://soundbible.com/grab.php?id=1746&type=mp3"
+    }
+  })
+  
+  const params = new URLSearchParams(window.location.search);
+  if (! params.has("print-pdf")) {
+    Reveal.registerPlugin(RevealCustomControls)
+  }
+  Reveal.registerPlugin(RevealCountDown)
+
 ```

--- a/countdown.js
+++ b/countdown.js
@@ -4,18 +4,28 @@
  *
  * @author Christer Eriksson
  */
-var RevealCountDown =
-  window.RevealCountDown ||
-  (function() {
-    var options = Reveal.getConfig().countdown || {};
+window.RevealCountDown = window.RevealCountDown || {
+  id: 'RevealCountDown',
+  init: function(deck) {
+    initCountDown(deck);
+  },
+  togglePauseTimer: function() { togglePauseTimer(); },
+  increaseTime: function() { increaseTime(); },
+  decreseTime: function() { decreseTime(); }
+};
 
+
+const initCountDown = function(Reveal){
+    var options = Reveal.getConfig().countdown || {};
     var defaultOptions = {
       defaultTime: 300,
       autostart: "no",
       tDelta: 30,
       playTickSoundLast: 10,
       tickSound: "",
-      timeIsUpSound: ""
+      timeIsUpSound: "",
+      plusKey: 187,
+      minusKey: 189
     };
 
     defaults(options, defaultOptions);
@@ -55,7 +65,7 @@ var RevealCountDown =
 
     Reveal.addKeyBinding(
       {
-        keyCode: 187,
+        keyCode: options.plusKey,
         key: "+",
         description: "Increase timer with tDelta seconds"
       },
@@ -64,7 +74,7 @@ var RevealCountDown =
 
     Reveal.addKeyBinding(
       {
-        keyCode: 189,
+        keyCode: options.minusKey,
         key: "-",
         description: "Decrease time with tDelta seconds"
       },
@@ -134,9 +144,8 @@ var RevealCountDown =
       running = autostart === "yes" ? true : false;
     }
 
-    return {
-      init: function() {}
-    };
-  })();
-
-Reveal.registerPlugin("countdown", RevealCountDown);
+    this.togglePauseTimer = togglePauseTimer;
+    this.increaseTime = increaseTime;
+    this.decreseTime = decreseTime;
+    return this;
+};


### PR DESCRIPTION
Hi Christer,

I've been using a newer version of reveal and the plugin was not initialized correctly. Besides, I found out that not all `+` and  `-` have the same keyCodes so I've added them as parameters. 

Feel free to merge or cancel this PR. 

Note: Now that I think maybe the way of initializing a plugin has not changed and `initialize()` can be used, but I'm not sure (since I'm not using directly reveal.js and I have to do it this way). 